### PR TITLE
headers: fix quadratic complexity in folding

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -405,7 +405,8 @@ impl Parser {
                                 if value.is_empty() {
                                     flags.set(HeaderFlags::VALUE_EMPTY);
                                 }
-                                return Ok((rest, Value::new(&value, flags)));
+                                // i is now the latest rest
+                                return Ok((i, Value::new(&value, flags)));
                             }
                             Err(Incomplete(_)) => {
                                 return Err(Incomplete(Needed::new(1)));


### PR DESCRIPTION
As found by oss-fuzz https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55002

The error is due to some fancy variable shadowing :
```
let (rest, _) = self.value_bytes()(input)?;
loop {
    if condition {
        return Ok((rest, something));
    }
let (rest, (val_bytes, ((_eol, other_flags), fold))) = self.value_bytes()(i)?;
}
```

The `rest` being returned is the first one, not the latest one whose scope is just the end of the loop :-p