### PR TITLE
bstr: use ascii white space instead of unicode

### DIFF
--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -62,7 +62,7 @@ impl Bstr {
 
     /// Compare trimmed bstr with the given slice, ingnoring ascii case.
     pub fn cmp_nocase_trimmed<B: AsRef<[u8]>>(&self, other: B) -> Ordering {
-        let lefts = &self.trim();
+        let lefts = &self.trim_with(|c| c.is_ascii_whitespace());
         let rights = &other.as_ref();
         let left = LowercaseIterator::new(lefts);
         let right = LowercaseIterator::new(rights);


### PR DESCRIPTION
To avoid DOS

fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55535
like from 2 minutes to 2 seconds to process 100 kilobytes...