### PR TITLE
request: do not url decode body data

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1001,7 +1001,6 @@ impl ConnectionParser {
                 // Keep track of the body length.
                 self.request_mut().request_entity_len += data.unwrap_or(b"").len() as u64;
                 let _ = self.request_mut().request_process_multipart_data(data);
-                let _ = self.request_mut().request_process_urlencoded_data(data);
                 // Send data to the callbacks.
                 let data = ParserData::from(data);
                 let mut data = Data::new(self.request_mut(), &data);

--- a/src/request.rs
+++ b/src/request.rs
@@ -578,7 +578,9 @@ impl ConnectionParser {
                             if nom_is_space(*c) {
                                 afterspace = true;
                             } else if afterspace || is_space(*c) {
-                                break;
+                                // We're done with this request.
+                                self.request_state = State::FINALIZE;
+                                return Ok(());
                             }
                         }
                     }


### PR DESCRIPTION
As it is the source of quadratic complexity,
And this is not done by Suricata with the C version, as it needs to enabled by some config call

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56677&q=label%3AProj-libhtp