### PR TITLE
test: still have a time limit

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -149,7 +149,7 @@ pub fn TestConfig() -> Config {
     cfg.set_server_personality(HtpServerPersonality::APACHE_2)
         .unwrap();
     // The default bomb limit may be slow in some development environments causing tests to fail.
-    cfg.compression_options.set_time_limit(u32::MAX);
+    cfg.compression_options.set_time_limit(10 * cfg.compression_options.get_time_limit());
     cfg.set_parse_urlencoded(true);
 
     cfg


### PR DESCRIPTION
even if it is bigger than the default one

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63985